### PR TITLE
Allow `command` to be a function returning an array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var respawns = function(defaults) {
 	};
 
 	group.add = function(id, command, opts) {
-		if (!Array.isArray(command)) return group.add(id, command.command, command);
+		if (typeof(command) != 'function' && !Array.isArray(command)) return group.add(id, command.command, command);
 		opts = xtend(defaults, opts);
 
 		var mon = respawn(command, opts);


### PR DESCRIPTION
(sister request to https://github.com/mafintosh/respawn/pull/9)

We're using respawn + respawn-group to run a set of ffmpeg processes, each generating an output video file. When something goes wrong to have the process respawn, the output filename (and thus the command running it) should change.

With the PR the `command` argument would be allowed to be a function returning the command array.
